### PR TITLE
Update copyright year display in the bottom of site page #224

### DIFF
--- a/site_config/site.js
+++ b/site_config/site.js
@@ -100,7 +100,7 @@ export default {
         },
       ],
     },
-    copyright: 'Copyright © 2018 The Apache Software Foundation. Apache and the Apache feather logo are trademarks of The Apache Software Foundation.',
+    copyright: 'Copyright © 2018' + ((new Date().getFullYear() > 2018) ? ('-' + new Date().getFullYear()) : '') + ' The Apache Software Foundation. Apache and the Apache feather logo are trademarks of The Apache Software Foundation.',
   },
   'zh-cn': {
     pageMenu: [
@@ -198,6 +198,6 @@ export default {
         }
       ]
     },
-    copyright: 'Copyright © 2018 The Apache Software Foundation. Apache and the Apache feather logo are trademarks of The Apache Software Foundation.'
+    copyright: 'Copyright © 2018' + ((new Date().getFullYear() > 2018) ? ('-' + new Date().getFullYear()) : '') + ' The Apache Software Foundation. Apache and the Apache feather logo are trademarks of The Apache Software Foundation.'
   }
 };


### PR DESCRIPTION
## What is the purpose of the change

Update copyright year display in the bottom of site page.

Fixes #224 

## Brief changelog

Use new Date().getFullYear() to get the current Year, if it's greater than 2018, add it after the 2018.

Using getFullYear, when the next year is coming, the code need't to modify;

Add the if check to avoid the user's client time less or equal than 2018, which will meet most condition.




