### PR TITLE
Add 2019 year number for copyright year of 'zh-cn' in site.js

### DIFF
--- a/site_config/site.js
+++ b/site_config/site.js
@@ -198,6 +198,6 @@ export default {
         }
       ]
     },
-    copyright: 'Copyright © 2018 The Apache Software Foundation. Apache and the Apache feather logo are trademarks of The Apache Software Foundation.'
+    copyright: 'Copyright © 2018-2019 The Apache Software Foundation. Apache and the Apache feather logo are trademarks of The Apache Software Foundation.'
   }
 };


### PR DESCRIPTION
## What is the purpose of the change

Add 2019 year number for copyright year of 'zh-cn' in site.js, the supplement of #225 

## Brief changelog

@see  #224 

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo-website/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Test your code locally by running `docsite start`, and make sure it works as expected.
- [ ] Make sure no files under build directory is added.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
